### PR TITLE
fix: use localhost:5000 for registry references

### DIFF
--- a/k8s/base/deployment.yaml
+++ b/k8s/base/deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: newsbrief
-          image: kind-registry:5000/newsbrief:dev-latest
+          image: localhost:5000/newsbrief:dev-latest
           ports:
             - containerPort: 8787
               name: http

--- a/k8s/overlays/dev/kustomization.yaml
+++ b/k8s/overlays/dev/kustomization.yaml
@@ -26,7 +26,7 @@ patches:
         value: newsbrief-dev
 
 images:
-  - name: kind-registry:5000/newsbrief
+  - name: localhost:5000/newsbrief
     newTag: dev-latest
 
 # Dev-specific configuration overrides

--- a/k8s/overlays/prod/kustomization.yaml
+++ b/k8s/overlays/prod/kustomization.yaml
@@ -29,7 +29,7 @@ patches:
   - path: deployment-patch.yaml
 
 images:
-  - name: kind-registry:5000/newsbrief
+  - name: localhost:5000/newsbrief
     # This will be updated by CI pipeline with semantic version
     newTag: v0.7.5
 

--- a/tekton/pipelines/ci-dev.yaml
+++ b/tekton/pipelines/ci-dev.yaml
@@ -32,8 +32,8 @@ spec:
       description: Git branch or tag to checkout
     - name: image-registry
       type: string
-      default: "kind-registry:5000"
-      description: Container registry URL (kind-registry for in-cluster access)
+      default: "localhost:5000"
+      description: Container registry URL
     - name: image-name
       type: string
       default: "newsbrief"

--- a/tekton/pipelines/ci-prod.yaml
+++ b/tekton/pipelines/ci-prod.yaml
@@ -40,8 +40,8 @@ spec:
       description: Git branch or tag to checkout
     - name: image-registry
       type: string
-      default: "kind-registry:5000"
-      description: Container registry URL (kind-registry for in-cluster access)
+      default: "localhost:5000"
+      description: Container registry URL
     - name: image-name
       type: string
       default: "newsbrief"


### PR DESCRIPTION
kind-registry:5000 not resolvable from Kind nodes on macOS.