### PR TITLE
chore: Update prod manifest to v0.8.0

### DIFF
--- a/k8s/overlays/prod/kustomization.yaml
+++ b/k8s/overlays/prod/kustomization.yaml
@@ -43,7 +43,7 @@ patches:
 images:
   - name: localhost:5000/newsbrief
     # This will be updated by CI pipeline with semantic version
-    newTag: v0.7.8
+    newTag: v0.8.0
 
 # Prod-specific configuration overrides
 configMapGenerator:


### PR DESCRIPTION
Update Kustomize image tag for production deployment to v0.8.0

Made with [Cursor](https://cursor.com)