### PR TITLE
fix(ci): update trivy-action to v0.36.0 (v0.28.0 removed)

### DIFF
--- a/.github/workflows/ci-prod.yml
+++ b/.github/workflows/ci-prod.yml
@@ -138,7 +138,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Trivy scan (table — visible in logs)
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ needs.build-and-push.outputs.digest }}
           format: table
@@ -146,7 +146,7 @@ jobs:
           exit-code: "0"
 
       - name: Trivy scan (SARIF — blocks on CRITICAL)
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ needs.build-and-push.outputs.digest }}
           format: sarif
@@ -200,7 +200,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate CycloneDX SBOM
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ needs.build-and-push.outputs.digest }}
           format: cyclonedx


### PR DESCRIPTION
## Summary

- `aquasecurity/trivy-action@0.28.0` was removed from the GitHub Actions marketplace, causing the Security Scan job to fail with "unable to find version 0.28.0"
- Updated all three uses (table scan, SARIF scan, SBOM generation) to `v0.36.0`

## Test plan

- [ ] Merge → prod pipeline re-runs → Security Scan passes → v0.8.3.1 release completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)