### PR TITLE
fix(ci): add checkout to sign-image job so cosign.pub is available

### DIFF
--- a/.github/workflows/ci-prod.yml
+++ b/.github/workflows/ci-prod.yml
@@ -168,6 +168,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-and-push, security-scan]
     steps:
+      - uses: actions/checkout@v4
+
       - uses: sigstore/cosign-installer@v3
 
       - uses: docker/login-action@v3


### PR DESCRIPTION
## Summary

`cosign verify --key cosign.pub` was failing with "no such file or directory" because the `sign-image` job had no `actions/checkout` step — the working directory was empty so `cosign.pub` from the repo was never on disk.

Added `actions/checkout@v4` as the first step in `sign-image`.

## Test plan

- [ ] Merge → prod pipeline re-runs → Sign Image passes → v0.8.3.1 release completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)