### PR TITLE
fix(ci): upgrade all actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -11,15 +11,16 @@ permissions:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: deim0s13/newsbrief
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: pip
@@ -55,9 +56,9 @@ jobs:
       CI: "true"
       DATABASE_URL: postgresql://newsbrief:newsbrief@localhost:5432/newsbrief_test
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: pip
@@ -82,11 +83,11 @@ jobs:
     outputs:
       sha-tag: ${{ steps.tags.outputs.sha-tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -99,7 +100,7 @@ jobs:
           echo "sha-tag=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${SHORT_SHA}" >> $GITHUB_OUTPUT
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -117,7 +118,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-push
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ci-prod.yml
+++ b/.github/workflows/ci-prod.yml
@@ -13,15 +13,16 @@ permissions:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: deim0s13/newsbrief
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: pip
@@ -57,9 +58,9 @@ jobs:
       CI: "true"
       DATABASE_URL: postgresql://newsbrief:newsbrief@localhost:5432/newsbrief_test
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: pip
@@ -86,7 +87,7 @@ jobs:
       version: ${{ steps.version.outputs.version }}
       image-ref: ${{ steps.version.outputs.image-ref }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Extract version from pyproject.toml
         id: version
@@ -101,9 +102,9 @@ jobs:
           echo "tag=v${VERSION}" >> $GITHUB_OUTPUT
           echo "image-ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:v${VERSION}" >> $GITHUB_OUTPUT
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -111,7 +112,7 @@ jobs:
 
       - name: Build and push
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -131,7 +132,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-push
     steps:
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -168,11 +169,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-and-push, security-scan]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: sigstore/cosign-installer@v3
+      - uses: sigstore/cosign-installer@v4
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -196,7 +197,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-and-push, security-scan]
     steps:
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -210,7 +211,7 @@ jobs:
           output: sbom-${{ needs.build-and-push.outputs.version }}.json
 
       - name: Upload SBOM artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: sbom
           path: sbom-${{ needs.build-and-push.outputs.version }}.json
@@ -221,10 +222,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-and-push, sign-image, generate-sbom]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Download SBOM artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: sbom
 
@@ -244,7 +245,7 @@ jobs:
           } > RELEASE_NOTES.md
 
       - name: Create GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ needs.build-and-push.outputs.version }}
           name: v${{ needs.build-and-push.outputs.version }}
@@ -258,7 +259,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-and-push, create-release]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

Forced Node.js 24 migration on GitHub Actions runners lands **June 16, 2026** (10 days away). This upgrades all actions in both `ci-prod.yml` and `ci-dev.yml` to their latest major version, which includes Node.js 24 runtime support.

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | `@v4` | `@v6` |
| `actions/setup-python` | `@v5` | `@v6` |
| `docker/login-action` | `@v3` | `@v4` |
| `docker/setup-buildx-action` | `@v3` | `@v4` |
| `docker/build-push-action` | `@v6` | `@v7` |
| `actions/upload-artifact` | `@v4` | `@v7` |
| `actions/download-artifact` | `@v4` | `@v8` |
| `softprops/action-gh-release` | `@v2` | `@v3` |
| `sigstore/cosign-installer` | `@v3` | `@v4` |
| `aquasecurity/trivy-action` | `@v0.36.0` | unchanged |
| `github/codeql-action/upload-sarif` | `@v3` | unchanged |

Also adds `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"` at the workflow env level as belt-and-suspenders.

## Test plan

- [ ] Dev CI run completes green (lint, test, build, push, manifest update)
- [ ] No Node.js 20 deprecation warnings in the run log
- [ ] Image digest output from `docker/build-push-action@v7` still propagates correctly to downstream jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)