### PR TITLE
feat(cd): zero-manual-step deployment on macOS and Windows

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,18 +6,16 @@
 # =============================================================================
 # DATABASE
 # =============================================================================
-# Development: PostgreSQL via Docker/Podman (make db-up)
-# Uses port 5433 to avoid conflict with production PostgreSQL (5432)
-# The dev database uses default credentials - DO NOT use in production!
-DATABASE_URL=postgresql://newsbrief:newsbrief_dev@localhost:5433/newsbrief
+# Production URL — used by make deploy (Compose uses 'db' hostname, port 5432)
+# make env-init substitutes CHANGE_ME_USE_MAKE_ENV_INIT with a generated password
+# in both DATABASE_URL and POSTGRES_PASSWORD, keeping them in sync automatically.
+DATABASE_URL=postgresql://newsbrief:CHANGE_ME_USE_MAKE_ENV_INIT@db:5432/newsbrief
 
-# Production: PostgreSQL password (REQUIRED - use make env-init to generate)
-# Development default 'newsbrief_dev' is insecure, ok for local only
+# Password for the PostgreSQL container — must match the password in DATABASE_URL above
 POSTGRES_PASSWORD=CHANGE_ME_USE_MAKE_ENV_INIT
 
-# Production database URL (container networking uses 'db' hostname, port 5432)
-# Uncomment for production deployment:
-# DATABASE_URL=postgresql://newsbrief:YOUR_PASSWORD@db:5432/newsbrief
+# Development URL (override DATABASE_URL when running make dev / make dev-full):
+# DATABASE_URL=postgresql://newsbrief:newsbrief_dev@localhost:5433/newsbrief
 
 # =============================================================================
 # LLM / OLLAMA
@@ -34,6 +32,13 @@ OLLAMA_BASE_URL=http://host.containers.internal:11434
 # API_KEY=
 # OAUTH_CLIENT_SECRET=
 # ENCRYPTION_KEY=
+
+# =============================================================================
+# NOTIFICATIONS (optional)
+# =============================================================================
+# ntfy.sh topic for local deploy notifications — same value as GitHub secret NTFY_TOPIC
+# Used by scripts/compose-watch.sh to send a push notification after auto-deploy
+NTFY_TOPIC=
 
 # =============================================================================
 # RATE LIMITING

--- a/Makefile
+++ b/Makefile
@@ -143,17 +143,21 @@ run:
 		--name newsbrief $(IMAGE_BASE):$(word 1,$(TAGS))
 
 # ---------- Production Deployment ----------
-deploy:                           ## Deploy production stack (containers + PostgreSQL)
+deploy:                           ## Deploy production stack (start, migrate, auto-create secret)
+	@test -f .env || { echo "❌ .env not found — run: make env-init"; exit 1; }
 	@echo "🚀 Deploying NewsBrief production stack..."
-	@if $(RUNTIME) secret inspect db_password >/dev/null 2>&1; then \
-		echo "🔐 Using Podman Secrets for database credentials"; \
-		$(RUNTIME)-compose -f compose.yaml -f compose.prod.yaml up -d --build; \
-	else \
-		echo "⚠️  No secret found - using .env file (run 'make secrets-create' for production)"; \
-		$(RUNTIME)-compose up -d --build; \
+	@if ! $(RUNTIME) secret inspect db_password >/dev/null 2>&1; then \
+		echo "🔑 Creating db_password secret from .env..."; \
+		grep '^POSTGRES_PASSWORD=' .env | cut -d= -f2- | \
+			$(RUNTIME) secret create db_password -; \
 	fi
-	@echo "✅ Production deployed at https://$(HOSTNAME)"
-	@echo "📊 View logs: make deploy-logs"
+	@$(RUNTIME)-compose -f compose.yaml -f compose.prod.yaml up -d --build
+	@echo "⏳ Waiting for database..."
+	@until $(RUNTIME) exec newsbrief-db pg_isready -U newsbrief -d newsbrief \
+		>/dev/null 2>&1; do sleep 1; done
+	@echo "🔧 Applying migrations..."
+	@$(RUNTIME)-compose -f compose.yaml -f compose.prod.yaml exec -T api alembic upgrade head
+	@echo "✅ Running at http://localhost:8787"
 
 deploy-stop:                      ## Stop production stack (preserves data)
 	@echo "🛑 Stopping production stack..."
@@ -163,10 +167,10 @@ deploy-stop:                      ## Stop production stack (preserves data)
 deploy-status:                    ## Check production stack status
 	@$(RUNTIME)-compose ps
 
-deploy-init:                      ## First-time setup: run migrations on fresh database
-	@echo "🔧 Initializing production database..."
-	$(RUNTIME)-compose exec api alembic upgrade head
-	@echo "✅ Database initialized"
+deploy-init:                      ## Run migrations on production database (also called by make deploy)
+	@echo "🔧 Running migrations on production database..."
+	$(RUNTIME)-compose -f compose.yaml -f compose.prod.yaml exec -T api alembic upgrade head
+	@echo "✅ Database up to date"
 
 # ---------- Compose (dev/debugging) ----------
 up:
@@ -210,7 +214,7 @@ db-psql:                            ## Connect to PostgreSQL with psql
 
 db-reset:                           ## Reset development database (WARNING: deletes all data)
 	@echo "⚠️  This will delete all development data!"
-	@read -p "Continue? [y/N] " confirm && [ "$$confirm" = "y" ] || exit 1
+	@bash -c 'read -p "Continue? [y/N] " confirm && [ "$$confirm" = "y" ]' || exit 1
 	$(RUNTIME)-compose -f compose.dev.yaml down -v
 	$(RUNTIME)-compose -f compose.dev.yaml up -d
 	@echo "Waiting for PostgreSQL to be ready..."
@@ -237,9 +241,7 @@ db-backup-list:                     ## List available backups
 # ---------- Secrets Management (Production) ----------
 secrets-create:  ## Create Podman secret for database password
 	@echo "Creating Podman secret for database password..."
-	@read -sp "Enter database password: " pwd && echo && \
-		echo "$$pwd" | $(RUNTIME) secret create db_password - && \
-		echo "✅ Secret created: db_password"
+	@bash -c 'read -sp "Enter database password: " pwd && echo && echo "$$pwd" | $(RUNTIME) secret create db_password - && echo "✅ Secret created: db_password"'
 
 secrets-list:  ## List Podman secrets
 	$(RUNTIME) secret ls
@@ -446,16 +448,29 @@ argo-ui:  ## Port-forward Argo CD UI on 8443
 	@echo "Open https://localhost:8443"
 	kubectl port-forward svc/argocd-server -n argocd 8443:443
 
+# ---------- Compose CD (Windows) ----------
+compose-start:  ## Start Compose stack (idempotent — safe to call on boot)
+	@bash scripts/compose-start.sh
+
+compose-watch:  ## Check GHCR for newer image and redeploy if found
+	@bash scripts/compose-watch.sh
+
+compose-autostart-install:  ## Install Task Scheduler tasks for Compose auto-deploy (Windows)
+ifneq ($(UNAME_S),Darwin)
+	@powershell.exe -ExecutionPolicy Bypass -File scripts/compose-task-install.ps1
+else
+	@echo "compose-autostart-install is for Windows. On macOS use: make infra-autostart-install"
+endif
+
 # ---------- Setup ----------
 env-init:  ## Create .env from template with generated secure password
 	@if [ -f .env ]; then \
 		echo "⚠️  .env already exists. Delete it first or edit manually."; \
 		exit 1; \
 	fi
-	@cp .env.example .env
 	@PASSWORD=$$(openssl rand -base64 32 | tr -dc 'a-zA-Z0-9' | head -c 32) && \
-		sed -i.bak "s/CHANGE_ME_USE_MAKE_ENV_INIT/$$PASSWORD/" .env && rm -f .env.bak
-	@echo "✅ Created .env with secure generated password"
+		sed "s/CHANGE_ME_USE_MAKE_ENV_INIT/$$PASSWORD/g" .env.example > .env
+	@echo "✅ Created .env — run 'make deploy' to start the stack"
 	@echo "📝 Review .env and adjust OLLAMA_BASE_URL if needed"
 
 # ---------- Defaults ----------
@@ -470,4 +485,6 @@ env-init:  ## Create .env from template with generated secure password
 	hostname-setup hostname-check hostname-remove hostname-trust-cert hostname-regen-certs \
 	autostart-install autostart-uninstall autostart-status \
 	infra-start infra-autostart-install infra-autostart-uninstall infra-autostart-status \
-	recover status port-forwards argo-ui env-init
+	recover status port-forwards argo-ui \
+	compose-start compose-watch compose-autostart-install \
+	env-init

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -25,6 +25,12 @@ services:
       interval: 2s
       timeout: 2s
       retries: 10
+    networks:
+      - dev_net
 
 volumes:
   newsbrief_dev_data:
+
+networks:
+  dev_net:
+    name: newsbrief_dev_network

--- a/compose.yaml
+++ b/compose.yaml
@@ -33,13 +33,14 @@ services:
   api:
     build: .
     container_name: newsbrief
-    # Note: No port mapping - production only accessible via Caddy proxy at newsbrief.local
-    # For development, run: make dev (uses localhost:8787)
+    # Direct access on 8787 for Windows (TLS via Caddy on newsbrief.local when WSL2 forwarding is set up)
+    ports:
+      - "8787:8787"
     environment:
       ENVIRONMENT: production
       # Database connection - must match POSTGRES_PASSWORD above
       # If you change POSTGRES_PASSWORD, also update DATABASE_URL
-      DATABASE_URL: ${DATABASE_URL:-postgresql://newsbrief:newsbrief_dev@db:5432/newsbrief}
+      DATABASE_URL: ${DATABASE_URL}
       # Ollama LLM connection — Podman resolves host.containers.internal on macOS and Windows
       OLLAMA_BASE_URL: ${OLLAMA_BASE_URL:-http://host.containers.internal:11434}
     volumes:

--- a/docs/adr/0032-cross-platform-cd-strategy.md
+++ b/docs/adr/0032-cross-platform-cd-strategy.md
@@ -1,0 +1,136 @@
+# ADR-0032: Cross-Platform Continuous Delivery Strategy
+
+## Status
+**Accepted** — June 2026
+
+## Context
+
+NewsBrief runs on two personal machines — a macOS MBP and a Windows laptop (WSL2). CI is handled by GitHub Actions and already delivers a verified, signed image to GHCR on every merge. The missing piece is the **CD leg**: neither machine was automatically picking up new versions without a manual `make` command after CI completed.
+
+### What "done" looks like
+
+- A PR merges to `main`
+- GitHub Actions builds, tests, and pushes `ghcr.io/deim0s13/newsbrief:latest` to GHCR
+- **Both machines deploy the new version automatically**, including when a machine has been offline for days and comes back online
+
+### Constraints
+
+| Constraint | Detail |
+|---|---|
+| No cloud infrastructure | Both machines are personal laptops; no always-on server |
+| kind + WSL2 rootless Podman is unreliable | The kind cluster state does not survive WSL2 restarts; kubeconfig is not reliably exported |
+| macOS kind/ArgoCD has deployed successfully | The GitOps path works on macOS when the cluster is running |
+| Windows Compose deployment is proven | `podman-compose` runs the full stack reliably on Windows/WSL2 |
+| Must survive offline periods | A machine may be away for days; on next login it must catch up to the latest version |
+
+---
+
+## Options Considered
+
+### Option A: Fix kind on Windows (unified ArgoCD on both platforms)
+
+Run a full kind + ArgoCD stack on both machines, matching the macOS setup.
+
+**Pros:** Consistent GitOps model across both machines; single CD mechanism to reason about.
+
+**Cons:** kind with rootless Podman on WSL2 is unreliable — the API server returns HTML instead of JSON; kubeconfig is not written after cluster creation; this was attempted and abandoned. Fixing it would require either switching to Docker Desktop (licensed) or a different k8s distribution (k3d, k0s), both of which introduce new unknowns.
+
+### Option B: Drop ArgoCD everywhere, Compose + polling on both (unified)
+
+Use `podman-compose` on both machines with a background polling script that detects new GHCR image digests and redeploys.
+
+**Pros:** Single mechanism across both platforms; simple; already proven on Windows.
+
+**Cons:** Loses the GitOps model on macOS where ArgoCD already works; requires Compose to be stable on macOS (it runs there but hasn't been the primary deployment target).
+
+### Option C: Hybrid — ArgoCD on macOS, Compose + polling on Windows *(chosen)*
+
+Keep ArgoCD on the platform where it works; introduce Compose-based polling on the platform where it doesn't.
+
+**Pros:** Both machines get zero-manual-step CD with mechanisms already proven on each platform. No time spent fixing kind on WSL2. macOS retains GitOps benefits.
+
+**Cons:** Two different CD mechanisms to maintain; Windows deployments have up to 15 minutes of lag (polling interval) vs ArgoCD's ~3-minute poll. Divergence means a fresh Windows machine setup is different from macOS.
+
+---
+
+## Decision
+
+**Option C: Hybrid** — ArgoCD on macOS, Compose + GHCR polling on Windows.
+
+### Rationale
+
+- ArgoCD on macOS is operational and produces automatic deployments when the kind cluster is running. Replacing it with Compose would be pure churn.
+- kind + WSL2 rootless Podman failed in multiple attempts; investing more time in it is low-ROI for a personal machine.
+- A 15-minute polling interval on Windows is acceptable — this is a personal newsreader, not a production SLA.
+- Both paths use the same source of truth: `ghcr.io/deim0s13/newsbrief:latest` pushed by GitHub Actions CI.
+
+---
+
+## Implementation
+
+### macOS — ArgoCD (GitOps)
+
+```
+CI pushes image → updates k8s/overlays/prod/kustomization.yaml
+  ↓
+ArgoCD polls git every 3 min → detects new image tag
+  ↓
+Sync wave 1: newsbrief-db-migrate Job (alembic upgrade head)
+Sync wave 2: API Deployment rolls to new image
+```
+
+**Auto-start:** launchd runs `scripts/infra-start.sh` on every login. The script is idempotent — it creates the kind cluster if missing, waits for ArgoCD, and **applies `k8s/argocd/` Application CRs if they are not already registered**. This ensures ArgoCD survives cluster recreation after a reboot.
+
+### Windows — Compose + GHCR polling
+
+```
+CI pushes image to ghcr.io/deim0s13/newsbrief:latest
+  ↓
+scripts/compose-watch.sh (every 15 min via Task Scheduler)
+  → podman pull :latest
+  → compare running digest vs pulled digest
+  → if newer: podman-compose up -d → wait for DB → alembic upgrade head
+  → ntfy push notification on deploy
+```
+
+**Auto-start:** Task Scheduler fires `scripts/compose-start.sh` at login (30s delay to let Podman Desktop initialise). Compose stack comes up; watch fires 15 min later.
+
+**Install once:**
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts\compose-task-install.ps1
+```
+
+### CI — unchanged
+
+GitHub Actions already pushes:
+- `ghcr.io/deim0s13/newsbrief:latest` on every merge to `main`
+- `ghcr.io/deim0s13/newsbrief:v{version}` for tagged releases
+- `ghcr.io/deim0s13/newsbrief:dev-latest` on every push to `dev`
+
+Both CD paths track `:latest` (prod) or `:dev-latest` (dev environment).
+
+---
+
+## Consequences
+
+### Positive
+- Both machines deploy new versions without any manual commands after a PR merge
+- Machines that have been offline automatically catch up on next login
+- macOS retains full GitOps auditability (Git is the source of truth)
+- Windows deployment is simple and robust (no k8s complexity)
+
+### Negative
+- Two different CD mechanisms to understand and maintain
+- Windows has up to 15-minute deployment lag after CI completes
+- A Windows-side failure (Podman offline, GHCR unreachable) silently skips the update and retries next poll cycle
+
+### Neutral
+- Both platforms use the same GHCR image, so the deployed artefact is identical
+- Migrations run automatically on both paths (ArgoCD sync wave 1 on macOS; `alembic upgrade head` in watch script on Windows)
+
+## Related ADRs
+
+- [ADR-0015: Local Kubernetes Distribution](0015-local-kubernetes-distribution.md)
+- [ADR-0016: CI/CD Platform Migration](0016-cicd-platform-migration.md)
+- [ADR-0017: GitOps Tooling](0017-gitops-tooling.md)
+- [ADR-0019: CI/CD Pipeline Design](0019-cicd-pipeline-design.md)

--- a/kind/cluster-config.yaml
+++ b/kind/cluster-config.yaml
@@ -18,7 +18,7 @@ nodes:
     extraPortMappings:
       # HTTP ingress / ArgoCD
       - containerPort: 30080
-        hostPort: 8080
+        hostPort: 18080
         protocol: TCP
       # HTTPS ingress
       - containerPort: 30443

--- a/scripts/compose-start.sh
+++ b/scripts/compose-start.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Idempotent Compose stack startup. Called by Windows Task Scheduler on login.
+# Safe to call repeatedly — podman-compose up -d is a no-op when already running.
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+log() { echo "[newsbrief-start] $(date -u '+%Y-%m-%dT%H:%M:%SZ') $*"; }
+
+# Wait for Podman to become available (Podman Desktop may still be initialising)
+for i in $(seq 1 20); do
+    podman info >/dev/null 2>&1 && break
+    log "Waiting for Podman... ($i/20)"
+    sleep 3
+done
+
+podman info >/dev/null 2>&1 || { log "ERROR: Podman not available after 60s. Exiting."; exit 1; }
+
+log "Starting Compose stack..."
+podman-compose -f compose.yaml -f compose.prod.yaml up -d
+log "Stack is up."

--- a/scripts/compose-task-install.ps1
+++ b/scripts/compose-task-install.ps1
@@ -1,0 +1,72 @@
+# Register Compose auto-start and auto-update as Windows Task Scheduler tasks.
+# Run once from PowerShell (no admin required):
+#   powershell -ExecutionPolicy Bypass -File scripts\compose-task-install.ps1
+#
+# Or from WSL2:
+#   powershell.exe -ExecutionPolicy Bypass -File scripts/compose-task-install.ps1
+#
+# Tasks registered:
+#   "NewsBrief Compose Start" — runs compose-start.sh at login (30s delay)
+#   "NewsBrief Compose Watch" — runs compose-watch.sh every 15 minutes
+
+$ErrorActionPreference = "Stop"
+
+# Detect WSL distro name — defaults to "Ubuntu"; override with $env:WSL_DISTRO if needed
+$WslDistro  = if ($env:WSL_DISTRO) { $env:WSL_DISTRO } else { "Ubuntu" }
+
+# WSL2 path to the project root (adjust if your checkout is elsewhere)
+$ProjectDir = "/home/pleathen/projects/newsbrief"
+
+$LogDir = Join-Path (Split-Path -Parent $PSScriptRoot) "logs"
+New-Item -ItemType Directory -Force -Path $LogDir | Out-Null
+
+function Register-NB {
+    param(
+        [string]$Name,
+        [string]$ScriptRelPath,
+        $Trigger
+    )
+
+    Unregister-ScheduledTask -TaskName $Name -Confirm:$false -ErrorAction SilentlyContinue
+
+    $wslArgs = "-d $WslDistro -- bash $ProjectDir/$ScriptRelPath"
+    $action  = New-ScheduledTaskAction -Execute "wsl.exe" -Argument $wslArgs
+
+    $settings = New-ScheduledTaskSettingsSet `
+        -StartWhenAvailable `
+        -AllowStartIfOnBatteries `
+        -DontStopIfGoingOnBatteries `
+        -ExecutionTimeLimit (New-TimeSpan -Minutes 10)
+
+    $principal = New-ScheduledTaskPrincipal `
+        -UserId $env:USERNAME `
+        -LogonType Interactive
+
+    Register-ScheduledTask `
+        -TaskName $Name `
+        -Action $action `
+        -Trigger $Trigger `
+        -Settings $settings `
+        -Principal $principal `
+        -Description "NewsBrief: $Name" | Out-Null
+
+    Write-Host "Registered: $Name"
+}
+
+# Task 1: Start Compose stack at login (30s delay to let Podman Desktop initialise first)
+$loginTrigger        = New-ScheduledTaskTrigger -AtLogOn -User $env:USERNAME
+$loginTrigger.Delay  = "PT30S"
+Register-NB "NewsBrief Compose Start" "scripts/compose-start.sh" $loginTrigger
+
+# Task 2: Check GHCR for updates every 15 minutes
+$repeatTrigger = New-ScheduledTaskTrigger `
+    -RepetitionInterval (New-TimeSpan -Minutes 15) `
+    -Once -At (Get-Date)
+Register-NB "NewsBrief Compose Watch" "scripts/compose-watch.sh" $repeatTrigger
+
+Write-Host ""
+Write-Host "Tasks registered. Test them manually:"
+Write-Host "  Start-ScheduledTask 'NewsBrief Compose Start'"
+Write-Host "  Start-ScheduledTask 'NewsBrief Compose Watch'"
+Write-Host ""
+Write-Host "To remove: Unregister-ScheduledTask 'NewsBrief Compose Start','NewsBrief Compose Watch' -Confirm:`$false"

--- a/scripts/compose-watch.sh
+++ b/scripts/compose-watch.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Check GHCR for a newer image; redeploy + migrate if one is found.
+# Called by Windows Task Scheduler every 15 minutes.
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+# Load .env so NTFY_TOPIC is available (fail silently if absent)
+if [ -f .env ]; then
+    set -a
+    # shellcheck source=/dev/null
+    source .env
+    set +a
+fi
+
+IMAGE="ghcr.io/deim0s13/newsbrief:latest"
+mkdir -p logs
+LOG="logs/compose-watch.log"
+
+log() { echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ') $*" | tee -a "$LOG"; }
+
+# Wait for Podman (may be called right after boot)
+for i in $(seq 1 10); do
+    podman info >/dev/null 2>&1 && break
+    log "Waiting for Podman... ($i/10)"
+    sleep 3
+done
+
+if ! podman info >/dev/null 2>&1; then
+    log "Podman not available. Skipping update check."
+    exit 0
+fi
+
+RUNNING_DIGEST=$(podman inspect newsbrief --format '{{.ImageDigest}}' 2>/dev/null || echo "")
+
+log "Pulling $IMAGE..."
+if ! podman pull "$IMAGE" --quiet 2>/dev/null; then
+    log "Could not pull image (offline?). Skipping."
+    exit 0
+fi
+
+LATEST_DIGEST=$(podman image inspect "$IMAGE" --format '{{.Digest}}' 2>/dev/null || echo "")
+
+if [ -z "$LATEST_DIGEST" ]; then
+    log "Could not determine latest digest. Skipping."
+    exit 0
+fi
+
+if [ "$RUNNING_DIGEST" = "$LATEST_DIGEST" ]; then
+    log "Already at latest ($LATEST_DIGEST). No action needed."
+    exit 0
+fi
+
+log "New image detected. Deploying..."
+podman-compose -f compose.yaml -f compose.prod.yaml up -d
+
+log "Waiting for database..."
+until podman exec newsbrief-db pg_isready -U newsbrief -d newsbrief >/dev/null 2>&1; do
+    sleep 2
+done
+
+log "Running migrations..."
+podman-compose -f compose.yaml -f compose.prod.yaml exec -T api alembic upgrade head
+
+log "Deploy complete: $LATEST_DIGEST"
+
+if [ -n "${NTFY_TOPIC:-}" ]; then
+    curl -s -X POST \
+        -H "Title: NewsBrief auto-deployed" \
+        -H "Priority: default" \
+        -d "New version deployed on $(hostname -s)" \
+        "https://ntfy.sh/${NTFY_TOPIC}" >/dev/null || true
+fi

--- a/scripts/infra-start.sh
+++ b/scripts/infra-start.sh
@@ -38,16 +38,25 @@ kubectl wait \
 
 log "ArgoCD is ready"
 
-# 5. Trigger sync for both apps (async — ArgoCD will reconcile)
+# 5. Ensure ArgoCD Application CRs exist — cluster recreation wipes them
+if ! kubectl get application newsbrief-prod -n argocd >/dev/null 2>&1; then
+    log "ArgoCD Applications not found — applying from k8s/argocd/..."
+    kubectl apply -f "${PROJECT_ROOT}/k8s/argocd/"
+    log "Applications registered"
+else
+    log "ArgoCD Applications already registered"
+fi
+
+# 6. Trigger sync for both apps (async — auto-sync will also pick these up)
 argocd app sync newsbrief-dev --async 2>/dev/null \
     && log "Triggered sync: newsbrief-dev" \
-    || log "Warning: could not sync newsbrief-dev (ArgoCD CLI not configured?)"
+    || log "Warning: could not trigger newsbrief-dev sync (ArgoCD CLI not logged in?)"
 
 argocd app sync newsbrief-prod --async 2>/dev/null \
     && log "Triggered sync: newsbrief-prod" \
-    || log "Warning: could not sync newsbrief-prod"
+    || log "Warning: could not trigger newsbrief-prod sync"
 
-# 6. Re-establish port-forwards (kill any stale ones first)
+# 7. Re-establish port-forwards (kill any stale ones first)
 pkill -f "kubectl port-forward" 2>/dev/null || true
 sleep 1
 


### PR DESCRIPTION
## Summary

Closes the CD gap — both machines now deploy new versions automatically after a PR merge, with no manual `make` commands required.

- **macOS (ArgoCD)**: `infra-start.sh` now applies ArgoCD Application CRs if they were wiped by a cluster recreation, making the script fully idempotent across reboots
- **Windows (Compose + polling)**: new `scripts/compose-watch.sh` checks GHCR every 15 min for a newer image digest; if found, pulls, redeploys, runs migrations, and sends an ntfy push notification
- **Windows auto-start**: `scripts/compose-task-install.ps1` registers two Task Scheduler tasks — start at login (30s delay) and watch every 15 min — run once from PowerShell
- **Credential sync**: `make env-init` now does a global `sed` substitution so `DATABASE_URL` and `POSTGRES_PASSWORD` always get the same generated password, eliminating the auth mismatch that caused past deployment failures
- **`make deploy` improvements**: auto-creates the `db_password` Podman secret from `.env` if missing; waits for DB; runs `alembic upgrade head` — no separate `make deploy-init` needed
- **Network isolation**: `compose.dev.yaml` now uses an isolated `newsbrief_dev_network`, preventing the dev DB container from polluting the prod Compose network via DNS round-robin

## ADR

[ADR-0032: Cross-Platform CD Strategy](docs/adr/0032-cross-platform-cd-strategy.md) documents the hybrid decision.

## End-to-end flow after merge

```
PR merged to main
  → CI: build → push ghcr.io/deim0s13/newsbrief:latest → ntfy notification

macOS:  launchd → infra-start.sh → kind → ArgoCD → auto-sync → deploy
Windows: Task Scheduler → compose-watch.sh (every 15 min) → new digest? → pull → up → migrate
```

## Setup (Windows — one-time)

```powershell
powershell -ExecutionPolicy Bypass -File scripts\compose-task-install.ps1
```

## Test plan

- [ ] `make env-init` on a clean machine — verify `DATABASE_URL` password matches `POSTGRES_PASSWORD`
- [ ] `make deploy` with no pre-existing secret — verify secret auto-created, migrations run, app accessible at `http://localhost:8787`
- [ ] Run `scripts/compose-watch.sh` manually — verify "Already at latest" when up to date
- [ ] macOS: delete and recreate kind cluster → `make infra-start` → verify App CRs re-applied and ArgoCD syncs

🤖 Generated with [Claude Code](https://claude.com/claude-code)