### PR TITLE
fix(cd): production stack uses GHCR image; fix watch digest comparison

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ deploy:                           ## Deploy production stack (start, migrate, au
 		grep '^POSTGRES_PASSWORD=' .env | cut -d= -f2- | \
 			$(RUNTIME) secret create db_password -; \
 	fi
-	@$(RUNTIME)-compose -f compose.yaml -f compose.prod.yaml up -d --build
+	@$(RUNTIME)-compose -f compose.yaml -f compose.prod.yaml up -d
 	@echo "⏳ Waiting for database..."
 	@until $(RUNTIME) exec newsbrief-db pg_isready -U newsbrief -d newsbrief \
 		>/dev/null 2>&1; do sleep 1; done

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -1,13 +1,22 @@
 # Production overrides - use with: podman-compose -f compose.yaml -f compose.prod.yaml
-# Adds Podman Secrets support for secure credential management
+#
+# Two things this file does:
+#   1. Replaces the local build with the pre-built GHCR image so the watch
+#      script can compare digests correctly and auto-deploy on new releases
+#   2. Uses a Podman Secret for the DB password instead of a plain env var
 #
 # Setup:
-#   1. Create secret: make secrets-create
-#   2. Deploy: make deploy (automatically uses this file)
-#
-# Note: Secret must be named "db_password" (podman-compose limitation)
+#   make env-init   # generate .env with matching credentials
+#   make deploy     # auto-creates secret, pulls image, runs migrations
 
 services:
+  api:
+    # Use the pre-built GHCR image in production instead of building locally.
+    # compose-watch.sh compares the running container's image digest against
+    # the pulled GHCR digest to detect new releases.
+    image: ghcr.io/deim0s13/newsbrief:latest
+    build: null
+
   db:
     environment:
       # Override: Use secret file instead of env var

--- a/scripts/compose-watch.sh
+++ b/scripts/compose-watch.sh
@@ -32,7 +32,8 @@ if ! podman info >/dev/null 2>&1; then
     exit 0
 fi
 
-RUNNING_DIGEST=$(podman inspect newsbrief --format '{{.ImageDigest}}' 2>/dev/null || echo "")
+# Image ID (sha256) of what the running container is using
+RUNNING_ID=$(podman inspect newsbrief --format '{{.Image}}' 2>/dev/null || echo "")
 
 log "Pulling $IMAGE..."
 if ! podman pull "$IMAGE" --quiet 2>/dev/null; then
@@ -40,15 +41,16 @@ if ! podman pull "$IMAGE" --quiet 2>/dev/null; then
     exit 0
 fi
 
-LATEST_DIGEST=$(podman image inspect "$IMAGE" --format '{{.Digest}}' 2>/dev/null || echo "")
+# Image ID of the freshly pulled image
+LATEST_ID=$(podman image inspect "$IMAGE" --format '{{.Id}}' 2>/dev/null || echo "")
 
-if [ -z "$LATEST_DIGEST" ]; then
-    log "Could not determine latest digest. Skipping."
+if [ -z "$LATEST_ID" ]; then
+    log "Could not determine latest image ID. Skipping."
     exit 0
 fi
 
-if [ "$RUNNING_DIGEST" = "$LATEST_DIGEST" ]; then
-    log "Already at latest ($LATEST_DIGEST). No action needed."
+if [ "$RUNNING_ID" = "$LATEST_ID" ]; then
+    log "Already at latest ($LATEST_ID). No action needed."
     exit 0
 fi
 
@@ -63,7 +65,7 @@ done
 log "Running migrations..."
 podman-compose -f compose.yaml -f compose.prod.yaml exec -T api alembic upgrade head
 
-log "Deploy complete: $LATEST_DIGEST"
+log "Deploy complete: $LATEST_ID"
 
 if [ -n "${NTFY_TOPIC:-}" ]; then
     curl -s -X POST \


### PR DESCRIPTION
## What

Fixes a bug introduced in #301 that would have caused `compose-watch.sh` to redeploy on every run.

## Why

`compose.yaml` has `build: .` for the api service — meaning `make deploy` was building from local source, not pulling the GHCR image. The watch script compares the running container's image ID against the pulled GHCR image ID, so a locally-built container would never match and would trigger a redeploy every 15 minutes (an infinite loop of unnecessary redeploys).

## Changes

- `compose.prod.yaml`: override `api.image` to `ghcr.io/deim0s13/newsbrief:latest` and set `build: null` — production always runs the CI-built image
- `compose-watch.sh`: switch digest comparison from `{{.ImageDigest}}`/`{{.Digest}}` (OCI manifest digest, not always populated) to `{{.Image}}`/`{{.Id}}` (image content SHA256, reliably set for all pulled images)
- `Makefile`: remove `--build` from `make deploy` since prod pulls from GHCR

## Test plan

- [ ] `make deploy` — verify it pulls from GHCR rather than building locally
- [ ] `bash scripts/compose-watch.sh` — verify "Already at latest" when up to date
- [ ] After a new main-branch release: verify watch script detects new image and redeploys

🤖 Generated with [Claude Code](https://claude.com/claude-code)