### PR TITLE
fix(cd): use image+build in compose.yaml instead of build:null override

### DIFF
--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -10,13 +10,6 @@
 #   make deploy     # auto-creates secret, pulls image, runs migrations
 
 services:
-  api:
-    # Use the pre-built GHCR image in production instead of building locally.
-    # compose-watch.sh compares the running container's image digest against
-    # the pulled GHCR digest to detect new releases.
-    image: ghcr.io/deim0s13/newsbrief:latest
-    build: null
-
   db:
     environment:
       # Override: Use secret file instead of env var

--- a/compose.yaml
+++ b/compose.yaml
@@ -19,7 +19,7 @@ services:
     environment:
       POSTGRES_DB: newsbrief
       POSTGRES_USER: newsbrief
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-newsbrief_dev}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     volumes:
       - postgres_data:/var/lib/postgresql/data
     ports:
@@ -31,6 +31,9 @@ services:
       retries: 5
 
   api:
+    # image: used by production (make deploy pulls from GHCR, no --build)
+    # build: used by development (make dev or explicit --build flag)
+    image: ghcr.io/deim0s13/newsbrief:latest
     build: .
     container_name: newsbrief
     # Direct access on 8787 for Windows (TLS via Caddy on newsbrief.local when WSL2 forwarding is set up)


### PR DESCRIPTION
## What

Fixes the `TypeError: argument of type 'NoneType'` crash on `make deploy`.

## Why

`podman-compose` does not support `build: null` in override files — its normaliser receives `None` and fails when checking `"additional_contexts" in service["build"]`.

## Fix

Set `image: ghcr.io/deim0s13/newsbrief:latest` directly in `compose.yaml` alongside `build: .`:
- `make deploy` (no `--build`) → uses the pre-pulled GHCR image
- `make dev` / `--build` flag → builds locally from Dockerfile

`compose.prod.yaml` no longer needs an `api` block; the GHCR image is inherited from `compose.yaml`. Also removes the leftover `newsbrief_dev` fallback from `POSTGRES_PASSWORD` in `compose.yaml`.

## Verified

`make deploy` completes without error; `curl http://localhost:8787/health` returns `healthy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)