### PR TITLE
fix(ci): pin cosign-installer to v4.1.2

### DIFF
--- a/.github/workflows/ci-prod.yml
+++ b/.github/workflows/ci-prod.yml
@@ -171,7 +171,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: sigstore/cosign-installer@v4
+      - uses: sigstore/cosign-installer@v4.1.2
 
       - uses: docker/login-action@v4
         with:


### PR DESCRIPTION
Fixes prod CI failure — `sigstore/cosign-installer@v4` has no floating major version tag; latest release is v4.1.2. Pinning to the explicit version.