### PR TITLE
fix(cd): Windows compose-watch first-run and self-update fixes

### DIFF
--- a/k8s/overlays/dev/kustomization.yaml
+++ b/k8s/overlays/dev/kustomization.yaml
@@ -30,7 +30,7 @@ images:
   - name: localhost:5000/newsbrief
     newName: ghcr.io/deim0s13/newsbrief
     # Tag updated automatically by ci-dev.yml update-manifest job on each push to dev
-    newTag: sha-4bf6fdb
+    newTag: sha-ea0792d
 
 # Dev-specific configuration overrides
 configMapGenerator:

--- a/k8s/overlays/dev/kustomization.yaml
+++ b/k8s/overlays/dev/kustomization.yaml
@@ -30,7 +30,7 @@ images:
   - name: localhost:5000/newsbrief
     newName: ghcr.io/deim0s13/newsbrief
     # Tag updated automatically by ci-dev.yml update-manifest job on each push to dev
-    newTag: sha-32899b8
+    newTag: sha-f4eaba7
 
 # Dev-specific configuration overrides
 configMapGenerator:

--- a/k8s/overlays/dev/kustomization.yaml
+++ b/k8s/overlays/dev/kustomization.yaml
@@ -30,7 +30,7 @@ images:
   - name: localhost:5000/newsbrief
     newName: ghcr.io/deim0s13/newsbrief
     # Tag updated automatically by ci-dev.yml update-manifest job on each push to dev
-    newTag: sha-f4eaba7
+    newTag: sha-4bf6fdb
 
 # Dev-specific configuration overrides
 configMapGenerator:

--- a/scripts/compose-watch.ps1
+++ b/scripts/compose-watch.ps1
@@ -56,9 +56,12 @@ if ($LASTEXITCODE -ne 0) {
 
 $Image = "ghcr.io/deim0s13/newsbrief:latest"
 
-# SHA256 of the image the running container is using
-$RunningId = podman inspect newsbrief --format '{{.Image}}' 2>$null
-if ($LASTEXITCODE -ne 0) { $RunningId = "" }
+# SHA256 of the image the running container is using (empty if not yet deployed)
+$RunningId = ""
+try {
+    $output = podman inspect newsbrief --format '{{.Image}}' 2>&1
+    if ($LASTEXITCODE -eq 0) { $RunningId = $output }
+} catch { }
 
 Log "Pulling $Image..."
 $null = podman pull $Image --quiet 2>&1

--- a/scripts/compose-watch.ps1
+++ b/scripts/compose-watch.ps1
@@ -47,6 +47,13 @@ if ($LASTEXITCODE -ne 0) {
 
 Set-Location $ProjectRoot
 
+# Pull latest scripts and compose files before doing anything else
+Log "Pulling latest repo from main..."
+git pull origin main 2>&1 | ForEach-Object { Log $_ }
+if ($LASTEXITCODE -ne 0) {
+    Log "WARNING: git pull failed — continuing with current files."
+}
+
 $Image = "ghcr.io/deim0s13/newsbrief:latest"
 
 # SHA256 of the image the running container is using


### PR DESCRIPTION
Two CD script fixes needed before Windows prod first-run:

- `feat(cd)`: `compose-watch.ps1` now runs `git pull origin main` at startup so the Windows clone self-updates scripts and compose files on each daily run — no manual `git pull` needed after initial setup.
- `fix(cd)`: Wrap `podman inspect` in `try/catch` to handle first-run case where no containers exist yet. `ErrorActionPreference=Stop` was treating podman stderr as a terminating error, crashing the script before the log file was created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)