### PR TITLE
fix(cd): replace em-dashes with ASCII hyphens in PowerShell scripts

### DIFF
--- a/scripts/compose-start.ps1
+++ b/scripts/compose-start.ps1
@@ -1,6 +1,6 @@
 # Start the NewsBrief Compose stack idempotently.
 # Called by Windows Task Scheduler at login (30s delay).
-# No WSL2 required — runs native Podman Desktop commands.
+# No WSL2 required - runs native Podman Desktop commands.
 #
 # Manual run (from PowerShell or WSL2):
 #   powershell.exe -ExecutionPolicy Bypass -File scripts/compose-start.ps1

--- a/scripts/compose-task-install.ps1
+++ b/scripts/compose-task-install.ps1
@@ -1,5 +1,5 @@
 # Register Compose auto-start and auto-update as Windows Task Scheduler tasks.
-# No WSL2 required — tasks invoke native PowerShell scripts directly.
+# No WSL2 required - tasks invoke native PowerShell scripts directly.
 #
 # Run once from PowerShell (no admin required):
 #   powershell -ExecutionPolicy Bypass -File scripts\compose-task-install.ps1
@@ -8,8 +8,8 @@
 #   make compose-autostart-install
 #
 # Tasks registered:
-#   "NewsBrief Compose Start" — runs compose-start.ps1 at login (30s delay)
-#   "NewsBrief Compose Watch" — runs compose-watch.ps1 once daily at 06:00
+#   "NewsBrief Compose Start" - runs compose-start.ps1 at login (30s delay)
+#   "NewsBrief Compose Watch" - runs compose-watch.ps1 once daily at 06:00
 
 $ErrorActionPreference = "Stop"
 
@@ -22,7 +22,7 @@ function Register-NB {
 
     Unregister-ScheduledTask -TaskName $Name -Confirm:$false -ErrorAction SilentlyContinue
 
-    # Derive the PS1 path from this installer's own location — portable regardless
+    # Derive the PS1 path from this installer's own location - portable regardless
     # of whether the repo lives on a Windows path or a \\wsl$\ UNC path.
     $ps1Path = Join-Path $PSScriptRoot ($ScriptStem + ".ps1")
     $psArgs  = "-WindowStyle Hidden -NonInteractive -ExecutionPolicy Bypass -File `"$ps1Path`""

--- a/scripts/compose-watch.ps1
+++ b/scripts/compose-watch.ps1
@@ -1,6 +1,6 @@
 # Check GHCR for a newer image; redeploy + migrate if one is found.
 # Called by Windows Task Scheduler once daily at 06:00.
-# No WSL2 required — runs native Podman Desktop commands.
+# No WSL2 required - runs native Podman Desktop commands.
 #
 # Manual run (from PowerShell or WSL2):
 #   powershell.exe -ExecutionPolicy Bypass -File scripts/compose-watch.ps1
@@ -51,7 +51,7 @@ Set-Location $ProjectRoot
 Log "Pulling latest repo from main..."
 git pull origin main 2>&1 | ForEach-Object { Log $_ }
 if ($LASTEXITCODE -ne 0) {
-    Log "WARNING: git pull failed — continuing with current files."
+    Log "WARNING: git pull failed - continuing with current files."
 }
 
 $Image = "ghcr.io/deim0s13/newsbrief:latest"


### PR DESCRIPTION
PowerShell 5.x on Windows reads UTF-8 files without BOM as Windows-1252. The em-dash (U+2014) byte sequence `0xE2 0x80 0x94` includes `0x94`, which is a closing smart-quote in Windows-1252 — this broke string parsing in all three PS1 scripts.