### PR TITLE
fix(cd): wrap git pull in try/catch to suppress NativeCommandError

### DIFF
--- a/scripts/compose-watch.ps1
+++ b/scripts/compose-watch.ps1
@@ -49,7 +49,9 @@ Set-Location $ProjectRoot
 
 # Pull latest scripts and compose files before doing anything else
 Log "Pulling latest repo from main..."
-git pull origin main 2>&1 | ForEach-Object { Log $_ }
+try {
+    git pull origin main 2>&1 | ForEach-Object { Log $_ }
+} catch { }
 if ($LASTEXITCODE -ne 0) {
     Log "WARNING: git pull failed - continuing with current files."
 }


### PR DESCRIPTION
PowerShell 5.x raises NativeCommandError for any stderr output from native commands when `ErrorActionPreference=Stop`, including git's informational progress messages (e.g. 'From https://...'). Wrapping in try/catch lets the pull complete and the script continue.