### PR TITLE
fix(cd): use 'podman compose' subcommand instead of podman-compose

### DIFF
--- a/k8s/overlays/dev/kustomization.yaml
+++ b/k8s/overlays/dev/kustomization.yaml
@@ -30,7 +30,7 @@ images:
   - name: localhost:5000/newsbrief
     newName: ghcr.io/deim0s13/newsbrief
     # Tag updated automatically by ci-dev.yml update-manifest job on each push to dev
-    newTag: sha-ea0792d
+    newTag: sha-6607edf
 
 # Dev-specific configuration overrides
 configMapGenerator:

--- a/scripts/compose-start.ps1
+++ b/scripts/compose-start.ps1
@@ -34,11 +34,11 @@ if ($LASTEXITCODE -ne 0) {
 
 Log "Podman ready. Starting stack..."
 Set-Location $ProjectRoot
-podman-compose -f compose.yaml -f compose.windows.yaml up -d
+podman compose -f compose.yaml -f compose.windows.yaml up -d
 
 if ($LASTEXITCODE -eq 0) {
     Log "Stack started successfully."
 } else {
-    Log "ERROR: podman-compose exited with code $LASTEXITCODE."
+    Log "ERROR: podman compose exited with code $LASTEXITCODE."
     exit $LASTEXITCODE
 }

--- a/scripts/compose-watch.ps1
+++ b/scripts/compose-watch.ps1
@@ -84,9 +84,9 @@ if ($RunningId -eq $LatestId) {
 }
 
 Log "New image detected ($LatestId). Deploying..."
-podman-compose -f compose.yaml -f compose.windows.yaml up -d
+podman compose -f compose.yaml -f compose.windows.yaml up -d
 if ($LASTEXITCODE -ne 0) {
-    Log "ERROR: podman-compose up failed (exit $LASTEXITCODE)."
+    Log "ERROR: podman compose up failed (exit $LASTEXITCODE)."
     exit $LASTEXITCODE
 }
 
@@ -98,7 +98,7 @@ while ($true) {
 }
 
 Log "Running migrations..."
-podman-compose -f compose.yaml -f compose.windows.yaml exec -T api alembic upgrade head
+podman compose -f compose.yaml -f compose.windows.yaml exec -T api alembic upgrade head
 if ($LASTEXITCODE -ne 0) {
     Log "ERROR: alembic upgrade failed (exit $LASTEXITCODE)."
     exit $LASTEXITCODE


### PR DESCRIPTION
podman-compose is not installed on Windows; Podman 4.x+ ships compose as a built-in subcommand requiring no separate install.