### PR TITLE
chore(release): bump version to 0.8.4

### DIFF
--- a/k8s/overlays/dev/kustomization.yaml
+++ b/k8s/overlays/dev/kustomization.yaml
@@ -30,7 +30,7 @@ images:
   - name: localhost:5000/newsbrief
     newName: ghcr.io/deim0s13/newsbrief
     # Tag updated automatically by ci-dev.yml update-manifest job on each push to dev
-    newTag: sha-6607edf
+    newTag: sha-2100636
 
 # Dev-specific configuration overrides
 configMapGenerator:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "newsbrief"
-version = "0.8.3.1"
+version = "0.8.4"
 description = "Story-based News Aggregator with AI Synthesis"
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
pyproject.toml version was never bumped from 0.8.3.1. The prod CI reads this to set the image tag and GitHub release — without this change all prod CI runs silently published as v0.8.3.1 and the kustomization was never updated.