### PR TITLE
feat(ci): add version check gate to prod pipeline

### DIFF
--- a/.github/workflows/ci-prod.yml
+++ b/.github/workflows/ci-prod.yml
@@ -16,8 +16,30 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
+  check-version:
+    name: Version check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Fail if version tag already exists
+        run: |
+          VERSION=$(python3 -c "
+          import re, pathlib
+          content = pathlib.Path('pyproject.toml').read_text()
+          m = re.search(r'^version\s*=\s*\"([^\"]+)\"', content, re.MULTILINE)
+          print(m.group(1))
+          ")
+          if git tag | grep -q "^v${VERSION}$"; then
+            echo "ERROR: v${VERSION} already exists. Bump the version in pyproject.toml before merging to main."
+            exit 1
+          fi
+          echo "Version v${VERSION} is new — proceeding."
+
   lint:
     name: Lint
+    needs: check-version
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -39,6 +61,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    needs: check-version
     timeout-minutes: 15
     services:
       postgres:


### PR DESCRIPTION
Adds a `check-version` job as the first gate in `ci-prod.yml`. It reads the version from `pyproject.toml`, checks if a matching git tag already exists, and fails immediately if it does — preventing silent re-publication of the old version when the bump is forgotten. Both `lint` and `test` jobs now depend on this check.